### PR TITLE
feat: add navigation buttons on Home Page

### DIFF
--- a/frontEnd/src/components/header/Header.tsx
+++ b/frontEnd/src/components/header/Header.tsx
@@ -1,19 +1,43 @@
 import { useNavigate } from 'react-router-dom'
 
+
 const Header = () => {
-    const navigate = useNavigate();
+  const navigate = useNavigate();
+  const userInfo = localStorage.getItem("userInfo");
   return (
     <div className='w-full h-16 bg-black text-white font-mono px-6 flex justify-between items-center'>
-        <h1 className=' md:flex md:justify-center text-4xl font-mono font-medium text-transparent bg-clip-text bg-gradient-to-r 
-                      from-purple-400 to-pink-600'> 
-                        CodeCrack
-                </h1>
+      <h1 className=' md:flex md:justify-center text-4xl font-mono font-medium text-transparent bg-clip-text bg-gradient-to-r 
+                      from-purple-400 to-pink-600'>
+        CodeCrack
+      </h1>
 
-        <div className='p-2 flex justify-between'> 
-        <button onClick={() => navigate('/signin')} className='mx-2 border-2 px-4 py-2 rounded-md'> SignIn </button>
-        <button onClick={() => navigate('/signin')} className='mx-2  px-4 py-2 rounded-md bg-gradient-to-r 
-                             from-pink-400 to-pink-600'> SignUp </button>
-        </div>
+      <div className='p-2 flex justify-between'>
+        {userInfo ? (
+          <>
+            <button onClick={() => navigate('/problemlist')}
+              className='mx-2  px-4 py-2 rounded-md bg-gradient-to-r 
+          from-pink-400 to-pink-600'
+            >
+              Go to Problem List
+            </button>
+
+            <img className='relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full mx-4' src='https://github.com/shadcn.png' />
+          </>
+        ) : (
+          <>
+            <button onClick={() => navigate('/signin')}
+              className='mx-2 border-2 px-4 py-2 rounded-md'>
+              SignIn
+            </button>
+            <button onClick={() => navigate('/signup')}
+              className='mx-2  px-4 py-2 rounded-md bg-gradient-to-r 
+              from-pink-400 to-pink-600'>
+              SignUp
+            </button>
+          </>
+        )}
+
+      </div>
     </div>
   )
 }

--- a/frontEnd/src/components/header/Header.tsx
+++ b/frontEnd/src/components/header/Header.tsx
@@ -1,0 +1,21 @@
+import { useNavigate } from 'react-router-dom'
+
+const Header = () => {
+    const navigate = useNavigate();
+  return (
+    <div className='w-full h-16 bg-black text-white font-mono px-6 flex justify-between items-center'>
+        <h1 className=' md:flex md:justify-center text-4xl font-mono font-medium text-transparent bg-clip-text bg-gradient-to-r 
+                      from-purple-400 to-pink-600'> 
+                        CodeCrack
+                </h1>
+
+        <div className='p-2 flex justify-between'> 
+        <button onClick={() => navigate('/signin')} className='mx-2 border-2 px-4 py-2 rounded-md'> SignIn </button>
+        <button onClick={() => navigate('/signin')} className='mx-2  px-4 py-2 rounded-md bg-gradient-to-r 
+                             from-pink-400 to-pink-600'> SignUp </button>
+        </div>
+    </div>
+  )
+}
+
+export default Header

--- a/frontEnd/src/components/signin/UserSignIn.tsx
+++ b/frontEnd/src/components/signin/UserSignIn.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import {z} from "zod";
 import axios from "axios";
 import { useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 function UserSignIn(){
     const [user,setUser]=useState({
         email:"",
@@ -88,6 +89,8 @@ function UserSignIn(){
                     onChange={handleChange}
                 /> 
                 <Button onClick={handleClick} text="SignIn"></Button>
+
+                <p>Don't have an Account ? <Link to={"/signup"} className="text-pink-500 font-medium" > Register Here </Link></p>
                 {   
                     trigger && (
                         <div className="text-center m-2">

--- a/frontEnd/src/components/signup/UserSignUp.tsx
+++ b/frontEnd/src/components/signup/UserSignUp.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import { z } from "zod";
 import axios from "axios";
 import { useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 
 function UserSignUp() {
     const navigate=useNavigate();
@@ -104,6 +105,7 @@ function UserSignUp() {
                     onChange={handleChange}
                 />
                 <Button onClick={handleClick} text="Sign Up" />
+                <p>Already have an Account ? <Link to={"/signin"} className="text-pink-500 font-medium" > Login Here </Link></p>
                 {   
                     trigger && (
                         <div className="text-center m-2">

--- a/frontEnd/src/pages/Home.tsx
+++ b/frontEnd/src/pages/Home.tsx
@@ -1,4 +1,5 @@
 import { Link } from "react-router-dom";
+import Header from "../components/header/Header";
 
 function Home() {
   const userInfo = localStorage.getItem("userInfo");
@@ -10,7 +11,7 @@ function Home() {
             <p className=" p-2 rounded-md bg-red-800 w-auto"> Go to Problem List</p>
         </Link>
       ) : (
-        <Link to="/signup">Sign Up</Link>
+        <Header/>
       )}
     </>
   );

--- a/frontEnd/src/pages/Home.tsx
+++ b/frontEnd/src/pages/Home.tsx
@@ -1,18 +1,9 @@
-import { Link } from "react-router-dom";
 import Header from "../components/header/Header";
 
 function Home() {
-  const userInfo = localStorage.getItem("userInfo");
-
   return (
     <>
-      {userInfo ? (
-        <Link to="/problemlist">
-            <p className=" p-2 rounded-md bg-red-800 w-auto"> Go to Problem List</p>
-        </Link>
-      ) : (
-        <Header/>
-      )}
+       <Header/>
     </>
   );
 }


### PR DESCRIPTION
#1 #2 

 1. Added Two Navigation buttons on the home page, which would eventually make navigation between sign In and Sign up pages smooth.
 2. Updated the signIn and signUp form with new links to improve the navigation between two pages.

![Screenshot 2024-05-23 092255](https://github.com/ShauryaSood2003/CodeCrack/assets/95456830/71fb0f31-bc13-4228-b3a7-def5d7bf18f6)

Updated Sign Up page.
![Screenshot 2024-05-23 120529](https://github.com/ShauryaSood2003/CodeCrack/assets/95456830/f59178e3-6c4a-4773-83bb-3eb030b094bb)

Updated Sign In page.
![Screenshot 2024-05-23 120824](https://github.com/ShauryaSood2003/CodeCrack/assets/95456830/1ade97d4-5df0-40dd-8bd7-9114aa194842)

This is how the dashboard looks like when user is signed in.
![Screenshot 2024-05-23 120634](https://github.com/ShauryaSood2003/CodeCrack/assets/95456830/a9b2b665-0651-4414-917b-3d08076f4d11)


